### PR TITLE
actions: shell: use abspath for targetdir

### DIFF
--- a/regendoc/actions.py
+++ b/regendoc/actions.py
@@ -25,7 +25,7 @@ def shell(name, targetdir, action, verbose):
         src = os.path.join(
             os.path.abspath(os.path.dirname(action["file"])), action["cwd"]
         )
-        targetdir = os.path.join(targetdir, action["cwd"])
+        targetdir = os.path.abspath(os.path.join(targetdir, action["cwd"]))
         if os.path.isdir(targetdir):
             shutil.rmtree(targetdir)
         shutil.copytree(src, targetdir)


### PR DESCRIPTION
This is meant to handle cwd=".", where `isdir` is True, but `rmtree`
would fail.

An alternative might be to check for cwd="." explicitly, and not join
then.

Fixes https://github.com/pytest-dev/regendoc/commit/5457f54be6062973aced9b9def13cf0f706e0551#commitcomment-33020310.